### PR TITLE
Bump dependencies and work with assert-key that replaced pre-init-spec in Integrant

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,13 +2,13 @@
   :description "A library with helper functions, reader tags, and init-keys for Integrant"
   :url "https://github.com/kwrooijen/integrant-tools"
   :license {:name "MIT"}
-  :dependencies [[integrant "0.8.0"]]
+  :dependencies [[integrant "0.10.0"]]
   :plugins [[lein-cloverage "1.0.13"]
             [lein-shell "0.5.0"]
             [lein-ancient "0.6.15"]
             [lein-changelog "0.3.2"]]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.0"]]}
-             :provided {:dependencies [[integrant/repl "0.3.1"]]}}
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.11.4"]]}
+             :provided {:dependencies [[integrant/repl "0.3.3"]]}}
   :deploy-repositories [["clojars" {:url "https://clojars.org/repo"
                                     :username :env/clojars_user
                                     :password :env/clojars_pass

--- a/project.clj
+++ b/project.clj
@@ -3,9 +3,9 @@
   :url "https://github.com/kwrooijen/integrant-tools"
   :license {:name "MIT"}
   :dependencies [[integrant "0.10.0"]]
-  :plugins [[lein-cloverage "1.0.13"]
+  :plugins [[lein-cloverage "1.2.2"]
             [lein-shell "0.5.0"]
-            [lein-ancient "0.6.15"]
+            [lein-ancient "0.7.0"]
             [lein-changelog "0.3.2"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.11.4"]]}
              :provided {:dependencies [[integrant/repl "0.3.3"]]}}

--- a/src/integrant_tools/core.cljc
+++ b/src/integrant_tools/core.cljc
@@ -161,7 +161,7 @@
    (meta-init config (keys config)))
   ([config keys]
    {:pre [(map? config)]}
-   (ig/build config keys meta-init-key #'ig/assert-pre-init-spec ig/resolve-key)))
+   (ig/build config keys meta-init-key #'ig/wrapped-assert-key ig/resolve-key)))
 
 (defn meta-opts-init
   "Same as ig/init, but `opts` is merged into the resulting value's
@@ -171,7 +171,7 @@
    (meta-opts-init config (keys config)))
   ([config keys]
    {:pre [(map? config)]}
-   (ig/build config keys meta-opts-init-key #'ig/assert-pre-init-spec ig/resolve-key)))
+   (ig/build config keys meta-opts-init-key #'ig/wrapped-assert-key ig/resolve-key)))
 
 (defn meta-opts-resume
   "Same as ig/resume, but `opts` is merged into the resulting value's
@@ -187,7 +187,7 @@
             (if (contains? system k)
               (meta-opts-resume-key k v (-> system meta :integrant.core/build (get k)) (system k))
               (meta-opts-init-key k v)))
-          #'ig/assert-pre-init-spec
+          #'ig/wrapped-assert-key
           ig/resolve-key)))
 
 (defn select-keys

--- a/src/integrant_tools/core.cljc
+++ b/src/integrant_tools/core.cljc
@@ -1,8 +1,7 @@
 (ns integrant-tools.core
   (:refer-clojure :exclude [select-keys])
   (:require
-   [integrant.core :as ig]
-   [integrant-tools.keyword :as it.keyword]))
+   [integrant.core :as ig]))
 
 (defn- ->coll [k]
   (if (coll? k) k [k]))

--- a/src/integrant_tools/repl.clj
+++ b/src/integrant_tools/repl.clj
@@ -10,7 +10,7 @@
   (try
     (build)
     (catch clojure.lang.ExceptionInfo ex
-      (if-let [system (:system (ex-data ex))]
+      (when-let [system (:system (ex-data ex))]
         (try
           (ig/halt! system)
           (catch clojure.lang.ExceptionInfo halt-ex

--- a/test/integrant_tools/core_test.clj
+++ b/test/integrant_tools/core_test.clj
@@ -1,5 +1,5 @@
 (ns integrant-tools.core-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest testing is]]
             [integrant-tools.core :as it]
             [integrant.core :as ig]
             [clojure.edn :as edn]))

--- a/test/integrant_tools/core_test.clj
+++ b/test/integrant_tools/core_test.clj
@@ -17,7 +17,7 @@
 (defmethod ig/init-key :component/number [_ opts]
   (:return/value opts))
 
-(defmethod ig/init-key :component/symbol [_ opts]
+(defmethod ig/init-key :component/symbol [_ _opts]
   {})
 
 (def config-1

--- a/test/integrant_tools/edn_test.clj
+++ b/test/integrant_tools/edn_test.clj
@@ -1,5 +1,5 @@
 (ns integrant-tools.edn-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest testing is]]
             [integrant-tools.edn :as it.edn]))
 
 (def config-str


### PR DESCRIPTION
As specified in https://cljdoc.org/d/integrant/integrant/0.10.0/doc/changelog#090-alpha1-2023-08-04
`pre-init-spec` is removed. It's replaced by the more generic `assert-key` as described in https://github.com/weavejester/integrant/commit/f16d36da081b83619cf3851691512de16bfe146f. `assert-pre-init-spec` is superseded by `wrapped-assert-key`.